### PR TITLE
prepare 3.0.0 release

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -4,6 +4,11 @@ repo:
   public: node-client-sdk
   private: node-client-sdk-private
 
+branches:
+- name: main
+  description: 3.x
+- name: 2.x
+
 publications:
   - url: https://www.npmjs.com/package/launchdarkly-node-client-sdk
     description: npm

--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -22,7 +22,8 @@ app.get('/', (req, res) => {
     capabilities: [
       'client-side',
       'service-endpoints',
-      'tags'
+      'tags',
+      'user-type',
     ],
   });
 });

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,13 +15,8 @@
 
 html: prepare
 	../node_modules/.bin/typedoc --options typedoc.js
-	mv before-typedoc-package.json ../package.json
-	mv before-typedoc-package-lock.json ../package-lock.json
 
 prepare:
-	cp ../package.json before-typedoc-package.json
-	cp ../package-lock.json before-typedoc-package-lock.json
-	cd .. && npm install "typedoc@<0.20.0"
 	rm -rf build
 	mkdir build
 	@# Extract the whole module declaration from launchdarkly-js-sdk-common, then remove the first and last lines

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1,0 +1,7 @@
+ This is the API reference for the LaunchDarkly Client-Side Node SDK.
+ 
+ In typical usage, you will call [[initialize]] in the main process at startup time to obtain an
+ an instance of [[LDClient]].
+ 
+ For more information, see the [SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/node-js).
+ 

--- a/docs/typedoc.js
+++ b/docs/typedoc.js
@@ -1,3 +1,6 @@
+// Note that the format of this file is barely documented on the TypeDoc site. In general,
+// the properties are equivalent to the command-line options described here:
+// https://typedoc.org/api/
 
 let version = process.env.VERSION;
 if (!version) {
@@ -8,8 +11,7 @@ if (!version) {
 module.exports = {
   out: './build/html',
   name: 'LaunchDarkly Client-Side Node SDK (' + version + ')',
-  readme: 'none',                // don't add a home page with a copy of README.md
-  mode: 'file',                  // don't treat "typings.d.ts" itself as a parent module
-  includeDeclarations: true,     // allows it to process a .d.ts file instead of actual TS code
-  entryPoint: '"launchdarkly-node-client-sdk"'    // note extra quotes - workaround for a TypeDoc bug
+  readme: 'doc.md',
+  entryPointStrategy: 'resolve', // Allows us to specify the specific entrypoints.
+  entryPoints: ["./build/typings.d.ts"] // This is the updated version created by the makefile.
 };

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "jest-junit": "^14.0.1",
     "launchdarkly-js-test-helpers": "1.2.1",
     "prettier": "2.7.1",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "typedoc": "^0.23.24"
   },
   "jest": {
     "rootDir": "src",
@@ -64,7 +65,7 @@
   },
   "dependencies": {
     "launchdarkly-eventsource": "1.4.3",
-    "launchdarkly-js-sdk-common": "5.0.0",
+    "launchdarkly-js-sdk-common": "5.0.1",
     "node-localstorage": "^1.3.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest --ci",
     "check-typescript": "node_modules/typescript/bin/tsc",
     "contract-test-service": "npm --prefix contract-tests install && npm --prefix contract-tests start",
-    "contract-test-harness": "curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/main/downloader/run.sh \\ | VERSION=v1 PARAMS=\"-url http://localhost:8000 -debug -stop-service-at-end $TEST_HARNESS_PARAMS\" sh",
+    "contract-test-harness": "curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/main/downloader/run.sh \\ | VERSION=v2 PARAMS=\"-url http://localhost:8000 -debug -stop-service-at-end $TEST_HARNESS_PARAMS\" sh",
     "contract-tests": "npm run contract-test-service & npm run contract-test-harness"
   },
   "engines": {
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "launchdarkly-eventsource": "1.4.3",
-    "launchdarkly-js-sdk-common": "4.3.2",
+    "launchdarkly-js-sdk-common": "5.0.0",
     "node-localstorage": "^1.3.1"
   },
   "repository": {

--- a/src/__tests__/LDClient-events-test.js
+++ b/src/__tests__/LDClient-events-test.js
@@ -4,7 +4,7 @@ const { TestHttpHandlers, TestHttpServers, sleepAsync, withCloseable } = require
 
 describe('LDClient', () => {
   const envName = 'UNKNOWN_ENVIRONMENT_ID';
-  const user = { key: 'user' };
+  const context = { key: 'user' };
 
   // Event generation in general is tested in a non-platform-specific way in launchdarkly-js-sdk-common.
   // The following tests just demonstrate that the common client calls our platform object when it
@@ -15,7 +15,7 @@ describe('LDClient', () => {
     it('sends an event for track()', async () => {
       await withCloseable(TestHttpServers.start, async server => {
         const config = { bootstrap: {}, eventsUrl: server.url, diagnosticOptOut: true };
-        const client = LDClient.initialize(envName, user, config);
+        const client = LDClient.initialize(envName, context, config);
         await withCloseable(client, async () => {
           const data = { thing: 'stuff' };
           await client.waitForInitialization();
@@ -30,7 +30,7 @@ describe('LDClient', () => {
           const trackEvent = events[1];
           expect(trackEvent.kind).toEqual('custom');
           expect(trackEvent.key).toEqual('eventkey');
-          expect(trackEvent.userKey).toEqual(user.key);
+          expect(trackEvent.contextKeys).toEqual({ user: 'user' });
           expect(trackEvent.data).toEqual(data);
           expect(trackEvent.url).toEqual(null);
         });
@@ -65,7 +65,7 @@ describe('LDClient', () => {
       await withCloseable(TestHttpServers.start, async server => {
         server.byDefault(TestHttpHandlers.respond(202));
         const config = { bootstrap: {}, eventsUrl: server.url };
-        const client = LDClient.initialize(envName, user, config);
+        const client = LDClient.initialize(envName, context, config);
         await withCloseable(client, async () => {
           const data = await expectDiagnosticEventAndDiscardRegularEvent(server);
           expect(data.kind).toEqual('diagnostic-init');

--- a/src/__tests__/LDClient-streaming-test.js
+++ b/src/__tests__/LDClient-streaming-test.js
@@ -15,9 +15,9 @@ const {
 
 describe('LDClient streaming', () => {
   const envName = 'UNKNOWN_ENVIRONMENT_ID';
-  const user = { key: 'user' };
-  const encodedUser = 'eyJrZXkiOiJ1c2VyIn0';
-  const expectedGetUrl = '/eval/' + envName + '/' + encodedUser;
+  const context = { key: 'user' };
+  const encodedContext = 'eyJrZXkiOiJ1c2VyIn0';
+  const expectedGetUrl = '/eval/' + envName + '/' + encodedContext;
   const expectedReportUrl = '/eval/' + envName;
 
   it('makes GET request and receives an event', async () => {
@@ -34,7 +34,7 @@ describe('LDClient streaming', () => {
           streamUrl: server.url,
           sendEvents: false,
         };
-        await withCloseable(LDClient.initialize(envName, user, config), async client => {
+        await withCloseable(LDClient.initialize(envName, context, config), async client => {
           const changeEvents = eventSink(client, 'change:flag');
           await client.waitForInitialization();
 
@@ -62,7 +62,7 @@ describe('LDClient streaming', () => {
           sendEvents: false,
           useReport: true,
         };
-        await withCloseable(LDClient.initialize(envName, user, config), async client => {
+        await withCloseable(LDClient.initialize(envName, context, config), async client => {
           const changeEvents = eventSink(client, 'change:flag');
           await client.waitForInitialization();
 
@@ -71,7 +71,7 @@ describe('LDClient streaming', () => {
 
           expect(server.requestCount()).toEqual(1);
           const req = await server.nextRequest();
-          expect(req.body).toEqual(JSON.stringify(user));
+          expect(req.body).toEqual(JSON.stringify(context));
         });
       });
     });

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -5,7 +5,7 @@ const { TestHttpHandlers, TestHttpServers, withCloseable } = require('launchdark
 
 describe('LDClient', () => {
   const envName = 'UNKNOWN_ENVIRONMENT_ID';
-  const user = { key: 'user' };
+  const context = { key: 'user' };
 
   it('should exist', () => {
     expect(LDClient).toBeDefined();
@@ -20,7 +20,7 @@ describe('LDClient', () => {
       await withCloseable(TestHttpServers.start, async server => {
         server.byDefault(TestHttpHandlers.respondJson({}));
         const config = { baseUrl: server.url, sendEvents: false };
-        await withCloseable(LDClient.initialize(envName, user, config), async client => {
+        await withCloseable(LDClient.initialize(envName, context, config), async client => {
           await client.waitForInitialization();
         });
       });
@@ -30,7 +30,7 @@ describe('LDClient', () => {
       await withCloseable(TestHttpServers.start, async server => {
         server.byDefault(TestHttpHandlers.respondJson({}));
         const config = { baseUrl: server.url, sendEvents: false };
-        await withCloseable(LDClient.initialize(envName, user, config), async client => {
+        await withCloseable(LDClient.initialize(envName, context, config), async client => {
           await client.waitForInitialization();
 
           expect(server.requestCount()).toEqual(1);
@@ -50,7 +50,7 @@ describe('LDClient', () => {
         error: jest.fn(),
       };
       const config = { bootstrap: {}, sendEvents: false, logger: logger };
-      await withCloseable(LDClient.initialize(envName, user, config), async client => {
+      await withCloseable(LDClient.initialize(envName, context, config), async client => {
         await client.waitForInitialization();
 
         client.track('whatever');

--- a/src/__tests__/LDClient-tls-test.js
+++ b/src/__tests__/LDClient-tls-test.js
@@ -17,10 +17,10 @@ const stubLogger = {
 
 describe('LDClient TLS configuration', () => {
   const envName = 'UNKNOWN_ENVIRONMENT_ID';
-  const user = { key: 'user' };
-  const encodedUser = 'eyJrZXkiOiJ1c2VyIn0';
-  const expectedPollingUrl = '/sdk/evalx/' + envName + '/users/' + encodedUser;
-  const expectedStreamingUrl = '/eval/' + envName + '/' + encodedUser;
+  const context = { key: 'user' };
+  const encodedContext = 'eyJrZXkiOiJ1c2VyIn0';
+  const expectedPollingUrl = '/sdk/evalx/' + envName + '/contexts/' + encodedContext;
+  const expectedStreamingUrl = '/eval/' + envName + '/' + encodedContext;
 
   it('can connect via HTTPS to a server with a self-signed certificate, if CA is specified', async () => {
     await withCloseable(TestHttpServers.startSecure, async server => {
@@ -31,7 +31,7 @@ describe('LDClient TLS configuration', () => {
         tlsParams: { ca: server.certificate },
         diagnosticOptOut: true,
       };
-      await withCloseable(LDClient.initialize(envName, user, config), async client => {
+      await withCloseable(LDClient.initialize(envName, context, config), async client => {
         await client.waitForInitialization();
       });
     });
@@ -46,7 +46,7 @@ describe('LDClient TLS configuration', () => {
         logger: stubLogger,
         diagnosticOptOut: true,
       };
-      await withCloseable(LDClient.initialize(envName, user, config), async client => {
+      await withCloseable(LDClient.initialize(envName, context, config), async client => {
         await expect(client.waitForInitialization()).rejects.toThrow(/network error.*self[- ]signed/);
       });
     });
@@ -68,7 +68,7 @@ describe('LDClient TLS configuration', () => {
           tlsParams: { ca: server.certificate },
           diagnosticOptOut: true,
         };
-        await withCloseable(LDClient.initialize(envName, user, config), async client => {
+        await withCloseable(LDClient.initialize(envName, context, config), async client => {
           const changeEvents = eventSink(client, 'change:flag');
 
           await client.waitForInitialization();
@@ -91,7 +91,7 @@ describe('LDClient TLS configuration', () => {
         tlsParams: { ca: server.certificate },
         diagnosticOptOut: true,
       };
-      await withCloseable(LDClient.initialize(envName, user, config), async client => {
+      await withCloseable(LDClient.initialize(envName, context, config), async client => {
         await client.waitForInitialization();
         await client.flush();
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const nodePlatform = require('./nodePlatform');
 const packageJson = require('../package.json');
 
 // This creates a client-side SDK instance to be used in Node.
-function initialize(env, user, options = {}) {
+function initialize(env, context, options = {}) {
   // Pass our platform object to the common code to create the Node version of the client
   const platform = nodePlatform(options);
   const extraOptionDefs = {
@@ -14,7 +14,7 @@ function initialize(env, user, options = {}) {
   if (!options.logger) {
     extraOptionDefs.logger = { default: basicLogger() };
   }
-  const clientVars = common.initialize(env, user, options, platform, extraOptionDefs);
+  const clientVars = common.initialize(env, context, options, platform, extraOptionDefs);
 
   clientVars.start();
 

--- a/test-types.ts
+++ b/test-types.ts
@@ -4,11 +4,11 @@
 
 import * as ld from 'launchdarkly-node-client-sdk';
 
-var ver: string = ld.version;
+const ver: string = ld.version;
 
-var emptyOptions: ld.LDOptions = {};
-var logger: ld.LDLogger = ld.basicLogger({ level: 'info' });
-var allOptions: ld.LDOptions = {
+const emptyOptions: ld.LDOptions = {};
+const logger: ld.LDLogger = ld.basicLogger({ level: 'info' });
+const allOptions: ld.LDOptions = {
   bootstrap: { },
   baseUrl: '',
   eventsUrl: '',
@@ -19,18 +19,16 @@ var allOptions: ld.LDOptions = {
   evaluationReasons: true,
   sendEvents: true,
   allAttributesPrivate: true,
-  privateAttributeNames: [ 'x' ],
-  inlineUsersInEvents: true,
-  allowFrequentDuplicateEvents: true,
+  privateAttributes: [ 'x' ],
   sendEventsOnlyForVariation: true,
   flushInterval: 1,
   streamReconnectDelay: 1,
-  logger: logger,
-  autoAliasingOptOut: true
+  logger: logger
 };
-var userWithKeyOnly: ld.LDUser = { key: 'user' };
-var anonymousUser: ld.LDUser = { key: 'anon-user', anonymous: true };
-var user: ld.LDUser = {
+const userWithKeyOnly: ld.LDUser = { key: 'user' };
+const contextWithKey: ld.LDContext = {kind: 'user', key: 'user-key'};
+const anonymousUser: ld.LDUser = { key: 'anon-user', anonymous: true };
+const user: ld.LDUser = {
   key: 'user',
   name: 'name',
   firstName: 'first',
@@ -50,7 +48,31 @@ var user: ld.LDUser = {
   },
   privateAttributeNames: [ 'name', 'email' ]
 };
-var client: ld.LDClient = ld.initialize('env', user, allOptions);
+
+const singleContext: ld.LDContext = {
+  kind: 'user',
+  key: 'user',
+  name: 'name',
+  firstName: 'first',
+  lastName: 'last',
+  email: 'test@example.com',
+  avatar: 'http://avatar.url',
+  ip: '1.1.1.1',
+  country: 'us',
+  anonymous: true,
+  _meta: {
+    privateAttributes: ['country']
+  }
+};
+
+const multiContext: ld.LDContext = {
+  kind: 'multi',
+  user: { key: 'user-key' },
+  org: { key: 'org-key' }
+};
+
+
+const client: ld.LDClient = ld.initialize('env', user, allOptions);
 
 client.waitUntilReady().then(() => {});
 client.waitForInitialization().then(() => {});
@@ -59,21 +81,32 @@ client.identify(user).then(() => {});
 client.identify(user, undefined, () => {});
 client.identify(user, 'hash').then(() => {});
 
-client.alias(user, anonymousUser);
+client.identify(contextWithKey).then(() => {});
+client.identify(contextWithKey, undefined, () => {});
+client.identify(contextWithKey, 'hash').then(() => {});
 
-var user: ld.LDUser = client.getUser();
+client.identify(singleContext).then(() => {});
+client.identify(singleContext, undefined, () => {});
+client.identify(singleContext, 'hash').then(() => {});
+
+client.identify(multiContext).then(() => {});
+client.identify(multiContext, undefined, () => {});
+client.identify(multiContext, 'hash').then(() => {});
+
+
+const context: ld.LDContext = client.getContext();
 
 client.flush(() => {});
 client.flush().then(() => {});
 
-var boolFlagValue: ld.LDFlagValue = client.variation('key', false);
-var numberFlagValue: ld.LDFlagValue = client.variation('key', 2);
-var stringFlagValue: ld.LDFlagValue = client.variation('key', 'default');
+const boolFlagValue: ld.LDFlagValue = client.variation('key', false);
+const numberFlagValue: ld.LDFlagValue = client.variation('key', 2);
+const stringFlagValue: ld.LDFlagValue = client.variation('key', 'default');
 
-var detail: ld.LDEvaluationDetail = client.variationDetail('key', 'default');
-var detailValue: ld.LDFlagValue = detail.value;
-var detailIndex: number | undefined = detail.variationIndex;
-var detailReason: ld.LDEvaluationReason | undefined = detail.reason;
+const detail: ld.LDEvaluationDetail = client.variationDetail('key', 'default');
+const detailValue: ld.LDFlagValue = detail.value;
+const detailIndex: number | undefined = detail.variationIndex;
+const detailReason: ld.LDEvaluationReason | undefined = detail.reason;
 
 client.setStreaming(true);
 client.setStreaming();
@@ -86,8 +119,8 @@ client.track('event');
 client.track('event', { someData: 'x' });
 client.track('event', null, 3.5);
 
-var flagSet: ld.LDFlagSet = client.allFlags();
-var flagSetValue: ld.LDFlagValue = flagSet['key'];
+const flagSet: ld.LDFlagSet = client.allFlags();
+const flagSetValue: ld.LDFlagValue = flagSet['key'];
 
 client.close(() => {});
 client.close().then(() => {});

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,11 +1,3 @@
-/**
- * This is the API reference for the LaunchDarkly Client-Side Node SDK.
- *
- * In typical usage, you will call [[initialize]] in the main process at startup time to obtain an
- * an instance of [[LDClient]].
- *
- * For more information, see the [SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/node-js).
- */
 declare module 'launchdarkly-node-client-sdk' {
 
 //// DOCBUILD-START-REPLACE  (see docs/Makefile)

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -20,7 +20,7 @@ declare module 'launchdarkly-node-client-sdk' {
     LDClientBase,
     LDLogger,
     LDOptionsBase,
-    LDUser
+    LDContext
   } from 'launchdarkly-js-sdk-common';
 //// DOCBUILD-END-REPLACE
 
@@ -39,22 +39,22 @@ declare module 'launchdarkly-node-client-sdk' {
    *
    * @param envKey
    *   The LaunchDarkly environment ID.
-   * @param user
-   *   The initial user properties. These can be changed later with [[LDClient.identify]].
-   *   The user must have a `key` property, except that if you omit `user.key` and set `user.anonymous` to
+   * @param context
+   *   The initial context properties. These can be changed later with [[LDClient.identify]].
+   *   The context must have a `key` property, except that if you omit `context.key` and set `context.anonymous` to
    *   true, the SDK will create a randomized unique key (which will be cached in local storage for the
    *   current OS user account, so the next initialization will reuse the same key).
    * @param options
    *   Optional configuration settings.
    */
-  export function initialize(envKey: string, user: LDUser, options?: LDOptions): LDClient;
+  export function initialize(envKey: string, context: LDContext, options?: LDOptions): LDClient;
 
   /**
    * Initialization options for the LaunchDarkly client.
    */
   export interface LDOptions extends LDOptionsBase {
     /**
-     * Determines where flag values and anonymous user keys are cached in the filesystem. By
+     * Determines where flag values and anonymous context keys are cached in the filesystem. By
      * default, this is the current directory.
      */
     localStoragePath?: string;


### PR DESCRIPTION
## [3.0.0] - 2023-01-12
The latest version of this SDK supports LaunchDarkly's new custom contexts feature. Contexts are an evolution of a previously-existing concept, "users." Contexts let you create targeting rules for feature flags based on a variety of different information, including attributes pertaining to users, organizations, devices, and more. You can even combine contexts to create "multi-contexts." 

This feature is only available to members of LaunchDarkly's Early Access Program (EAP). If you're in the EAP, you can use contexts by updating your SDK to the latest version and, if applicable, updating your Relay Proxy. Outdated SDK versions do not support contexts, and will cause unpredictable flag evaluation behavior.

If you are not in the EAP, only use single contexts of kind "user", or continue to use the user type if available. If you try to create contexts, the context will be sent to LaunchDarkly, but any data not related to the user object will be ignored.

For detailed information about this version, please refer to the list below. For information on how to upgrade from the previous version, please read the [migration guide](https://docs.launchdarkly.com/sdk/client-side/node-js/migration-2-to-3).

### Added:
- The types `LDContext`, `LDSingleKindContext`, and `LDMultiKindContext` define the new "context" model.
- All SDK methods that took an `LDUser` parameter now take an `LDContext`. `LDUser` is now a subset of `LDContext`, so existing code based on users will still work.

### Changed _(breaking changes from 3.x)_:
- There is no longer such a thing as a `secondary` meta-attribute that affects percentage rollouts. If you set an attribute with that name in `LDContext`, it will simply be a custom attribute like any other.
- Evaluations now treat the `anonymous` attribute as a simple boolean, with no distinction between a false state and an undefined state.
- `LDClient.getUser` has been replaced with `LDClient.getContext`.
- `privateAttributeNames` has been replaced with `privateAttributes` in `LDOptions`. Private attributes now allow using attribute references.
- Update the version of typedoc used for documentation generation, and update the documentation generation process.


### Changed (behavioral changes):
- Analytics event data now uses a new JSON schema due to differences between the context model and the old user model.

### Removed:
- Removed all types, fields, and methods that were deprecated as of the most recent 3.x release.
- Removed the `secondary` meta-attribute in `LDUser`.
- The `alias` method no longer exists because alias events are not needed in the new context model.
- The `autoAliasingOptOut` and `inlineUsersInEvents` options no longer exist because they are not relevant in the new context model.

### Deprecated:
- The `LDUser`  object has been deprecated. Support for `LDUser` is maintained to simplify the upgrade process, but it is recommended to use `LDContext` in the shape of either `LDSingleKindContext` or `LDMultiKindContext`.