### PR TITLE
fix: Correct typing and prevents warnings for secure mode hash during initialization.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ function initialize(env, context, options = {}) {
   const extraOptionDefs = {
     localStoragePath: { type: 'string' },
     tlsParams: { type: 'object' },
+    hash: { type: 'string' },
   };
   if (!options.logger) {
     extraOptionDefs.logger = { default: basicLogger() };

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -65,6 +65,14 @@ declare module 'launchdarkly-node-client-sdk' {
      * of the TLS-related parameters supported by `https.request()`, such as `ca`, `cert`, and `key`.
      */
     tlsParams?: LDTLSOptions;
+
+    /**
+     * The signed context key for Secure Mode.
+     *
+     * For more information, see the JavaScript SDK Reference Guide on
+     * [Secure mode](https://launchdarkly.com/docs/sdk/features/secure-mode#configure-secure-mode-in-javascript-based-sdks).
+     */
+    hash?: string;
   }
 
   /**


### PR DESCRIPTION
Updates the LDOptions typing with the secure mode hash option.
Include the hash in the extra type defs for the base.

Fixes #57 